### PR TITLE
Removing unnessesery placeSchema from GET /events

### DIFF
--- a/API.json
+++ b/API.json
@@ -740,10 +740,6 @@
             "type": "integer",
             "format": "int64",
             "example": 100
-          },
-          "placeSchema": {
-            "type": "string",
-            "example": "Seralized place schema"
           }
         }
       },

--- a/API.yaml
+++ b/API.yaml
@@ -475,9 +475,6 @@ components:
           type: integer
           format: int64
           example: 100
-        placeSchema:
-          type: string
-          example: Seralized place schema
   
     EventWithPlaces:
       required:


### PR DESCRIPTION
Listing events don't require placeSchema (serialized image). It's waste of transfer. Img is used only when showing certain event getting from /event/{id}